### PR TITLE
Update sonarr-9999.ebuild

### DIFF
--- a/net-nntp/sonarr/sonarr-9999.ebuild
+++ b/net-nntp/sonarr/sonarr-9999.ebuild
@@ -20,7 +20,7 @@ RDEPEND="
 	dev-db/sqlite"
 IUSE="updater"
 MY_PN="NzbDrone"
-S=${WORKDIR}/${MY_PN}
+S=${WORKDIR}/${PN}
 
 pkg_setup() {
 	enewgroup ${PN}


### PR DESCRIPTION
Doesn't work for me without this edit - fails with "The source directory '${S}' doesn't exist"