### PR TITLE
up-to-date sonarr package

### DIFF
--- a/net-nntp/sonarr/files/sonarr.init
+++ b/net-nntp/sonarr/files/sonarr.init
@@ -1,52 +1,28 @@
-#!/sbin/runscript
-# Copyright 1999-2015 Gentoo Foundation
+#!/sbin/openrc-run
+# Copyright 2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
-depend() {
-        need net
-}
-
-run_dir="/var/run/sonarr"
-pidfile="$run_dir/sonarr.pid"
-etc_dir="/etc/sonarr"
-var_dir="/var/sonarr"
 log_dir="/var/log/sonarr"
 log_file="sonarr.log"
-program="$APP_DIR/NzbDrone.exe"
-bin=`which mono`
 
-check_config() {
-    
-    if [ ! -d "${run_dir}" ]; then
-            mkdir "${run_dir}"
-    fi
+data_dir="/var/lib/sonarr"
 
-    # Permission stuff. Should ensure that the daemon user always have write permissions.
-    # Quick and ugly but should get the job done.
+program="/usr/share/NzbDrone/NzbDrone.exe"
+bin="$(which mono)"
 
-    chown -R ${USER}:${GROUP} "${run_dir}"
-        chown -R ${USER}.${GROUP} "${var_dir}"
-    chown -R ${USER}.${GROUP} "${etc_dir}"
-    if [ "${WEBUPDATER}" = "YES" ]; then
-                chown -R ${USER}.${GROUP} "${CODE_DIR}"
-        fi
+command="$bin $program"
+command_args="--daemon \
+  --log=${log_dir}/${log_file} \
+  --data_dir ${data_dir}"
+
+start_stop_daemon_args="--background \
+--user \"${USER}\" --group \"${GROUP}\""
+
+depend() {
+  need localmount net
 }
 
-start() {
-    check_config
-
-        ebegin "Starting Sonarr"
-
-        start-stop-daemon --start --background --make-pidfile --pidfile ${pidfile}\
-        -u ${USER} -g ${GROUP}\
-    --exec ${bin} ${program} -- \
-    --daemon --log=${log_dir}/${log_file} --data_dir ${var_dir}
-        eend $?
-}
-
-stop() {
-        ebegin "Stopping Sonarr"
-        start-stop-daemon --stop --pidfile ${pidfile} --retry 15
-        eend $?
+start_pre() {
+  checkpath -d -m 0755 -o "${USER}":"${GROUP}" "$data_dir"
+  checkpath -d -m 0755 -o "${USER}":"${GROUP}" "$log_dir"
 }

--- a/net-nntp/sonarr/sonarr-9999.ebuild
+++ b/net-nntp/sonarr/sonarr-9999.ebuild
@@ -26,11 +26,10 @@ pkg_setup() {
 	enewgroup ${PN}
 	enewuser ${PN} -1 -1 /var/lib/sonarr ${PN}
 }
-
-src_unpack() {
-	unpack ${A}
-	mv ${MY_PN} ${PN}
-}
+## src_unpack() {
+##	unpack ${A}
+##	mv ${MY_PN} ${PN}
+## }
 
 src_install() {
 	newconfd "${FILESDIR}/${PN}.conf" ${PN}


### PR DESCRIPTION
it's a live ebuild, so you'll need to regenerate the Manifest occasionally to match the new
upstream tarball at:

http://update.sonarr.tv/v2/master/mono/NzbDrone.master.tar.gz

(*size / hash changes are fairly common*)
